### PR TITLE
(SIMP-3291)  processgraph: Configure Travis to publish gem and release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
-/Gemfile.lock
+*.gem
+*.swp
+Gemfile.lock
+.bundle/
+*.old
+spec.log
+.vagrant
+/log
+/spec/fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+---
+language: ruby
+cache: bundler
+sudo: required
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y graphviz graphviz-devel graphviz-ruby
+  - rm Gemfile.lock || true
+bundler_args: "--without development --path .vendor"
+notifications:
+  email: false
+rvm:
+  - 2.1.9
+  - 2.3.3
+env:
+  - SIMP_SKIP_NON_SIMPOS_TESTS=1
+script:
+  - RUBYLIB=/usr/lib64/graphviz/ruby bundle exec rake spec
+matrix:
+  fast_finish: true
+before_deploy:
+  - bundle exec rake clobber
+  - "export GEM_VERSION=`ruby -r ./lib/simp/processgraph/version.rb -e 'puts Simp::ProcessGraph::VERSION'`"
+  - '[[ $TRAVIS_TAG =~ ^${GEM_VERSION}$ ]]'
+deploy:
+  - provider: rubygems
+    gemspec: simp-processgraph.gemspec
+    gem: simp-processgraph
+    api_key:
+      secure: "xVFp/NKOC237Kt2VA97uhnkCj7McAhYXgbzPgWExzFtvA/XACgSB1Y6tNOS1R9djZ3B5ILk/XN93sD5dLPbT6X9TYxzU+J3VSVO+tC7eNHU2PS7RNNI1/GI3IAPM/APOKTrfaUryVk1OcQ6JWTn2bGE0kd/mF5XRqNBvFP6MNe9YyC1MKASCAiRHZD02Sq3S8ykbBig16H1vipkhfWits8un+cet5SadOOwZCRkJGMmuCXlSoxqIarJ6joL2ffW9Kbpo4HKnNo0Oj2RNvHyVbfe/W1B04woqLaDoDUZ4GxROqW2L49uhN0NILzoNU9oU7f+BRnW1gG6C5lIAB1RZWlangds8as43yAIb0Y8m9dtSIQiZUKstt6kC7naDtdYPD1VDPv/Gg0TplebT3nAkCoK5oTAc/gMH4zd3cvEHBGoN+XJNNnOXhHM5hc46iraBmRa3487/xvaNUSc0cNq1m2x32qSqv2ux76pzEenzq5rxa4CsGtJwkpR9FINMEyJpA/anTauBKtDuPkG4ZpwO0ltRfxEV7OyElBxlMcsdmp+gWp8kMLWCCyrcXzstorHDMXs63LYpaEBU10ceXrSMYgc/OrmEH4hnMOXo9WFPzgHB68b6OP1pfPnUPjHIiE8dNLoF9mCwO8rVl3EbdDIGB5wB5T7kcBHiGXViZyqNCFE="
+    on:
+      tags: true
+      rvm: 2.1.9
+      condition: "($SKIP_PUBLISH != true)"
+  - provider: releases
+    api_key:
+      secure: "fL4Sr1a97HgwWlukC+cO8HCk963svGnkUMBoHppmtkterqvp2jULUxTo2H36zWQyInO9BB2iVcN9gOl9G1kkPI3MnnzAlkCSSIOgyRSjcMvI44osGDURf0nk4dWyKbzcTRFFfVa/9fxt98U1qUg2t9uMBf3hf+eUT1+GAEegQoiqRIxbKQtAYAkCIxD8MFXmTHSzuDwG4UbhZdmQzAeDY+NAJZiySGDV2JAYUye5VjuXrEeFiISvd4FMLSzfKzmd79OVZ3tlxCYgFAss+Zznvm3KT4ifD5t6Ro8uaAnmJBH1XEmAd22hUp8aHPWL1XVoyi3dxZqHB1Nf4Bk0QVWOu8BeVCIUeXO9cAOAdKiBHQ5PdOPpZN8wXE/stoXUGe4an9AqJoWYFGISLrKQyxNg2e9KrqEsfNkqwUYJJ0J5qlxt2cQFjn9UzKDF7t+PWhsP9vqQV+86av1RcjdVOMFpIs/OJzQwmZRwlk4YisMNREmj8wtG6Vj7zqQ2/468yznd7Yj8PTcLtQtWWhhpLXvEKRvjoaY58g2b9x7+cGn/usP1OUKsgvzs+s9dqPSSEGQScphUKy9vtpwAHw2V1daCMleeQxioJkxUaMtNb+1SZ+iOkKT1UzEq1OmBWtcUbEuoB0iRcNfkkGfQqVrRFcgZoPzLVK5yUapkiBCX4Nl7g34="
+    on:
+      tags: true
+      rvm: 2.1.9
+      condition: "($SKIP_PUBLISH != true)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ before_install:
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false
+# graphviz libraries are compiled against system ruby  
 rvm:
-  - 2.0.0
+  - system
 env:
   - SIMP_SKIP_NON_SIMPOS_TESTS=1
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false
-# graphviz libraries are compiled against system ruby because the library is installed from yum which uses system ruby
+# graphviz libraries installed from RPM are dynmically linked to the system ruby libraries
 rvm:
   - system
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y graphviz libgraphviz-dev libgv-ruby
+  - sudo gem install bundler
   - rm Gemfile.lock || true
 bundler_args: "--without development --path .vendor"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ cache: bundler
 sudo: required
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y graphviz graphviz-devel graphviz-ruby
+  - sudo apt-get install -y graphviz libgraphviz-dev libgv-ruby
   - rm Gemfile.lock || true
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false
 rvm:
-  - 2.1.9
-  - 2.3.3
+  - 2.0.0
 env:
   - SIMP_SKIP_NON_SIMPOS_TESTS=1
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 bundler_args: "--without development --path .vendor"
 notifications:
   email: false
-# graphviz libraries are compiled against system ruby  
+# graphviz libraries are compiled against system ruby because the library is installed from yum which uses system ruby
 rvm:
   - system
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 # mandatory gems
 gem 'bundler'
 gem 'rake'
-gem 'gv'
 
 group :system_tests do
   gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,16 @@
-# Gemfile for processgraph
-source 'https://rubygems.org'
+gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
+gem_sources.each { |gem_source| source gem_source }
+
+# read dependencies in from the gemspec
 gemspec
 
+# mandatory gems
 gem 'bundler'
-gem 'rake', '~> 10.0'
-gem 'rspec'
-gem 'pry'
+gem 'rake'
 gem 'gv'
+
+group :system_tests do
+  gem 'rspec'
+  gem 'pry'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ require 'find'
 CLEAN.include "#{@package}-*.gem"
 CLEAN.include 'pkg'
 CLEAN.include 'dist'
+CLEAN.include 'spec.log'
 Find.find( @rakefile_dir ) do |path|
   if File.directory? path
     CLEAN.include path if File.basename(path) == 'tmp'
@@ -44,7 +45,8 @@ task :spec do
   rtnval = `rspec spec > spec.log`
   puts " test results are #{$?}, logged in spec.log"
   if $? != 0
-    puts "spec tests failed, results in spec.log"
+#    puts "spec tests failed, results in spec.log"
+     puts IO.read('spec.log')
   else
     puts "spec tests passed - results are #{$?}, logged in spec.log"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,6 @@ task :spec do
   rtnval = `rspec spec > spec.log`
   puts " test results are #{$?}, logged in spec.log"
   if $? != 0
-#    puts "spec tests failed, results in spec.log"
      puts IO.read('spec.log')
   else
     puts "spec tests passed - results are #{$?}, logged in spec.log"

--- a/lib/simp/processgraph/version.rb
+++ b/lib/simp/processgraph/version.rb
@@ -1,0 +1,5 @@
+module Simp
+  module ProcessGraph
+    VERSION = '0.0.4'
+  end
+end

--- a/simp-processgraph.gemspec
+++ b/simp-processgraph.gemspec
@@ -12,9 +12,10 @@ Gem::Specification.new do |s|
   s.email       = 'simp@simp-project.org'
   s.files       = ["lib/simp-processgraph.rb"]
   s.homepage    = 'https://github.com/simp/rubygem-simp-processgraph'
-  s.metadata = {
-                 'issue_tracker' => 'https://simp-project.atlassian.net'
-               }
+  # s.metadata does not seem to work in ruby < 2, so it fails the travis test unless we have it commented out
+  # s.metadata = {
+  #               'issue_tracker' => 'https://simp-project.atlassian.net'
+  #             }
   s.executables = 'processgraph'
   s.license       = 'Apache-2.0'
 

--- a/simp-processgraph.gemspec
+++ b/simp-processgraph.gemspec
@@ -1,28 +1,26 @@
 $: << File.expand_path( '../lib/', __FILE__ )
+require 'simp/processgraph/version'
 require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'simp-processgraph'
-  s.version     = '0.0.4'
-  s.date        = '2016-01-06'
+  s.version     = Simp::ProcessGraph::VERSION
+  s.date        = Date.today.to_s
   s.summary     = "Visually displays process communications"
   s.description = "A program that uses dot and graphviz to graph your process relationships"
   s.authors     = ["SIMP team"]
   s.email       = 'simp@simp-project.org'
   s.files       = ["lib/simp-processgraph.rb"]
-  s.homepage    =
-    'https://github.com/simp/rubygem-simp-processgraph'
-  #s.metadata = {
-  #               'issue_tracker' => 'https://github.com/simp/rubygem-simp-processgraph/issues'
-  #             }
+  s.homepage    = 'https://github.com/simp/rubygem-simp-processgraph'
+  s.metadata = {
+                 'issue_tracker' => 'https://simp-project.atlassian.net'
+               }
   s.executables = 'processgraph'
   s.license       = 'Apache-2.0'
 
   # gem dependencies
   #   for the published gem
   s.required_ruby_version = '>=1.8.7'
-
-  # not using this s.add_runtime_dependency 'gviz',  '~> 0.3.5'
 
   # for development
   s.add_development_dependency 'rake',        '~> 10'


### PR DESCRIPTION
When the repo is tagged, publish to rubygems.org and release on github.

NOTE:  At this time, the travis build is NOT expected to pass.